### PR TITLE
Check for DRI2 extension and use when supported

### DIFF
--- a/src/core/os/lnx/dri3/dri3Loader.cpp
+++ b/src/core/os/lnx/dri3/dri3Loader.cpp
@@ -1204,6 +1204,7 @@ Dri3Loader::Dri3Loader()
     :
     m_pXcbDri3Id(nullptr),
     m_pXcbPresentId(nullptr),
+    m_pXcbDri2Id(nullptr),
     m_initialized(false)
 {
     memset(m_libraryHandles, 0, sizeof(m_libraryHandles));
@@ -1220,6 +1221,12 @@ xcb_extension_t* Dri3Loader::GetXcbDri3Id() const
 xcb_extension_t* Dri3Loader::GetXcbPresentId() const
 {
     return m_pXcbPresentId;
+}
+
+// =====================================================================================================================
+xcb_extension_t* Dri3Loader::GetXcbDri2Id() const
+{
+    return m_pXcbDri2Id;
 }
 
 // =====================================================================================================================
@@ -1516,6 +1523,14 @@ Result Dri3Loader::Init(
         {
             m_pXcbPresentId = reinterpret_cast<xcb_extension_t*>(dlsym(m_libraryHandles[LibXcbPresent], "xcb_present_id"));
         }
+        if (m_libraryHandles[LibXcbDri2] == nullptr)
+        {
+            result = Result::ErrorUnavailable;
+        }
+        else
+        {
+            m_pXcbDri2Id = reinterpret_cast<xcb_extension_t*>(dlsym(m_libraryHandles[LibXcbDri2], "xcb_dri2_id"));
+        }
         if (result == Result::Success)
         {
             m_initialized = true;
@@ -1534,3 +1549,4 @@ Dri3Loader::SpecializedInit(Platform* pPlatform)
 
 } //namespace Linux
 } //namespace Pal
+

--- a/src/core/os/lnx/dri3/dri3Loader.h
+++ b/src/core/os/lnx/dri3/dri3Loader.h
@@ -1062,18 +1062,18 @@ public:
 
     void   SpecializedInit(Platform* pPlatform);
 
-    xcb_extension_t* GetXcbDri2Id() const;
-
     xcb_extension_t* GetXcbDri3Id() const;
 
     xcb_extension_t* GetXcbPresentId() const;
 
-private:
-    xcb_extension_t* m_pXcbDri2Id;
+    xcb_extension_t* GetXcbDri2Id() const;
 
+private:
     xcb_extension_t* m_pXcbDri3Id;
 
     xcb_extension_t* m_pXcbPresentId;
+
+    xcb_extension_t* m_pXcbDri2Id;
 
     void* m_libraryHandles[Dri3LoaderLibrariesCount];
     bool  m_initialized;

--- a/src/core/os/lnx/dri3/dri3Loader.h
+++ b/src/core/os/lnx/dri3/dri3Loader.h
@@ -1062,11 +1062,15 @@ public:
 
     void   SpecializedInit(Platform* pPlatform);
 
+    xcb_extension_t* GetXcbDri2Id() const;
+
     xcb_extension_t* GetXcbDri3Id() const;
 
     xcb_extension_t* GetXcbPresentId() const;
 
 private:
+    xcb_extension_t* m_pXcbDri2Id;
+
     xcb_extension_t* m_pXcbDri3Id;
 
     xcb_extension_t* m_pXcbPresentId;

--- a/src/core/os/lnx/dri3/dri3WindowSystem.cpp
+++ b/src/core/os/lnx/dri3/dri3WindowSystem.cpp
@@ -441,8 +441,12 @@ int32 Dri3WindowSystem::OpenDri3()
     {
         constexpr char ProDdxVendorString[] = "amdgpu";
 
-        const xcb_dri2_connect_cookie_t dri2Cookie = m_dri3Procs.pfnXcbDri2Connect(m_pConnection, m_hWindow, DRI2DriverDRI);
-        xcb_dri2_connect_reply_t*const  pDri2Reply = m_dri3Procs.pfnXcbDri2ConnectReply(m_pConnection, dri2Cookie, NULL);
+        const xcb_dri2_connect_cookie_t dri2Cookie = m_dri3Procs.pfnXcbDri2Connect(m_pConnection,
+                                                                                   m_hWindow,
+                                                                                   DRI2DriverDRI);
+        xcb_dri2_connect_reply_t*const  pDri2Reply = m_dri3Procs.pfnXcbDri2ConnectReply(m_pConnection,
+                                                                                        dri2Cookie,
+                                                                                        NULL);
 
         if ((pDri2Reply != nullptr) && (m_dri3Procs.pfnXcbDri2ConnectDriverNameLength(pDri2Reply) > 0))
         {

--- a/src/core/os/lnx/dri3/dri3WindowSystem.h
+++ b/src/core/os/lnx/dri3/dri3WindowSystem.h
@@ -159,6 +159,7 @@ private:
     const SwapChainMode    m_swapChainMode;       // swapchain mode
     const xcb_window_t     m_hWindow;             // xcb window created by App
     xcb_connection_t*      m_pConnection;         // xcb connection created by App
+    bool                   m_dri2Supported;
     int32                  m_dri3MajorVersion;
     int32                  m_dri3MinorVersion;
     int32                  m_presentMajorVersion;

--- a/src/core/os/lnx/dri3/dri3WindowSystem.proc
+++ b/src/core/os/lnx/dri3/dri3WindowSystem.proc
@@ -53,3 +53,4 @@ libxcb-dri2.so.0    @proc xcb_dri2_connect_cookie_t xcb_dri2_connect (xcb_connec
 libxcb-dri2.so.0    @proc int xcb_dri2_connect_driver_name_length (const xcb_dri2_connect_reply_t* pReplay)
 libxcb-dri2.so.0    @proc char* xcb_dri2_connect_driver_name (const xcb_dri2_connect_reply_t* pReplay)
 libxcb-dri2.so.0    @proc xcb_dri2_connect_reply_t* xcb_dri2_connect_reply (xcb_connection_t* pConnection, xcb_dri2_connect_cookie_t cookie, xcb_generic_error_t** ppError)
+libxcb-dri2.so.0    @var xcb_extension_t xcb_dri2_id


### PR DESCRIPTION
Ensures that vulkan works correctly when DRI2 extension is missing, as is the case in Xwayland.