### PR TITLE
Removed unused local variable in PerfTrace for gfx6 and gfx9

### DIFF
--- a/src/core/hw/gfxip/gfx6/gfx6PerfTrace.cpp
+++ b/src/core/hw/gfxip/gfx6/gfx6PerfTrace.cpp
@@ -154,7 +154,6 @@ uint32* SpmTrace::WriteEndCommands(
     grbmGfxIndex.bits.SH_BROADCAST_WRITES       = 1;
 
     uint32 muxselAddrReg = mmRLC_SPM_SE_MUXSEL_ADDR__CI__VI;
-    const uint32 NumShaderEngines = m_device.Parent()->ChipProperties().gfx6.numShaderEngines;
 
     // Reset the muxsel addr register.
     for (uint32 seIndex = 0; seIndex < static_cast<uint32>(SpmDataSegmentType::Count); ++seIndex)
@@ -221,8 +220,6 @@ uint32* SpmTrace::WriteSetupCommands(
     }
 
     // (2) Write muxsel ram.
-    const uint32 NumShaderEngines = m_device.Parent()->ChipProperties().gfx6.numShaderEngines;
-
     for (uint32 seIndex = 0; seIndex < static_cast<uint32>(SpmDataSegmentType::Count); ++seIndex)
     {
         const uint32 muxselRamDwords = GetMuxselRamDwords(seIndex);

--- a/src/core/hw/gfxip/gfx9/gfx9PerfTrace.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9PerfTrace.cpp
@@ -118,8 +118,6 @@ uint32* Gfx9SpmTrace::WriteSetupCommands(
     }
 
     // (2) Write muxsel ram.
-    const uint32 NumShaderEngines = m_device.Parent()->ChipProperties().gfx6.numShaderEngines;
-
     for (uint32 seIndex = 0; seIndex < static_cast<uint32>(SpmDataSegmentType::Count); ++seIndex)
     {
         const uint32 muxselRamDwords = GetMuxselRamDwords(seIndex);
@@ -293,7 +291,6 @@ uint32* Gfx9SpmTrace::WriteEndCommands(
     grbmGfxIndex.gfx09.SH_BROADCAST_WRITES      = 1;
 
     uint32 muxselAddrReg = Gfx09::mmRLC_SPM_SE_MUXSEL_ADDR;
-    const uint32 NumShaderEngines = m_device.Parent()->ChipProperties().gfx9.numShaderEngines;
 
     // Reset the muxsel addr register.
     for (uint32 seIndex = 0; seIndex < static_cast<uint32>(SpmDataSegmentType::Count); ++seIndex)


### PR DESCRIPTION
NumShaderEngines does not seem to be used locally.