### PR TITLE
Include unistd.h instead of sys/unistd.h in ddPosixSocket.cpp

### DIFF
--- a/shared/gpuopen/src/posix/ddPosixSocket.cpp
+++ b/shared/gpuopen/src/posix/ddPosixSocket.cpp
@@ -34,13 +34,13 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <sys/unistd.h>
 #include <sys/fcntl.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
 #include <arpa/inet.h>
 
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
sys/unistd.h is not necessarily provided on all systems (e.g. Musl libc)
while unistd.h is.
This is needed to get AMDVLK running on Linux systems that use the Musl libc, additionally a patch for the rand48_r functions will be needed.