### PR TITLE
lnx/display: do no use DESTROY_DUMB to close GEM handles

### DIFF
--- a/src/core/os/lnx/display/displayWindowSystem.cpp
+++ b/src/core/os/lnx/display/displayWindowSystem.cpp
@@ -268,11 +268,11 @@ Result DisplayWindowSystem::ModeSet(
 void DisplayWindowSystem::DestroyPresentableImage(
     WindowSystemImageHandle hImage)
 {
-    drm_mode_destroy_dumb dreq = {};
+    drm_gem_close dreq = {};
 
     dreq.handle = hImage.hBuffer;
 
-    m_drmProcs.pfnDrmIoctl(m_drmMasterFd, DRM_IOCTL_MODE_DESTROY_DUMB, &dreq);
+    m_drmProcs.pfnDrmIoctl(m_drmMasterFd, DRM_IOCTL_GEM_CLOSE, &dreq);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The handle we get is from PrimeFDToHandle (et al) which should be closed
via GEM_CLOSE. Using the DESTROY_DUMB ioctl is a violation.

Seemingly a copy/paste mistake from mesa, with the latter fixed as of
commit bd0c4e360d08dc1b1a1433530b389358623783bb

Signed-off-by: Emil Velikov <emil.velikov@collabora.com>