### PR TITLE
Fix a clang warning: equality comparison with extraneous parentheses

### DIFF
--- a/src/core/hw/gfxip/gfx9/gfx9CmdUtil.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9CmdUtil.cpp
@@ -397,9 +397,9 @@ uint32 CmdUtil::ChainSizeInDwords(
     {
         sizeInBytes = sizeof(PM4PFP_INDIRECT_BUFFER);
     }
-    else if ((engineType == EngineTypeCompute)
+    else if (engineType == EngineTypeCompute
 #if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 530
-             || (engineType == EngineTypeExclusiveCompute)
+             || engineType == EngineTypeExclusiveCompute
 #endif
              )
     {


### PR DESCRIPTION
Clang 6 warned:
 .../gfx9CmdUtil.cpp:483:26: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
     else if ((engineType == EngineTypeCompute)
               ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 .../gfx9CmdUtil.cpp:483:26: note: remove extraneous parentheses around the comparison to silence this warning
     else if ((engineType == EngineTypeCompute)
              ~           ^                   ~
 .../gfx9CmdUtil.cpp:483:26: note: use '=' to turn this equality comparison into an assignment
     else if ((engineType == EngineTypeCompute)
                          ^~