### PR TITLE
Fix non gfx10 build

### DIFF
--- a/src/core/hw/gfxip/gfx9/gfx9Device.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9Device.cpp
@@ -659,11 +659,13 @@ Result Device::CreateDummyCommandStream(
         pCmdStream->Begin(beginFlags, nullptr);
 
         uint32* pCmdSpace = pCmdStream->ReserveCommands();
+#if LLPC_BUILD_GFX10
         if (engineType == EngineTypeDma)
         {
             pCmdSpace = DmaCmdBuffer::BuildNops(pCmdSpace, pCmdStream->GetSizeAlignDwords());
         }
         else
+#endif
         {
             pCmdSpace += m_cmdUtil.BuildNop(CmdUtil::MinNopSizeInDwords, pCmdSpace);
         }
@@ -1360,6 +1362,7 @@ Result Device::CreateCmdBuffer(
 
         *ppCmdBuffer = PAL_PLACEMENT_NEW(pPlacementAddr) UniversalCmdBuffer(*this, createInfo);
     }
+#if LLPC_BUILD_GFX10
     else if ((createInfo.queueType == QueueTypeDma) && IsGfx10(m_gfxIpLevel))
     {
         result = Result::Success;
@@ -1367,6 +1370,7 @@ Result Device::CreateCmdBuffer(
         // As of GFX10, DMA operations have become part of the graphics engine...
         *ppCmdBuffer = PAL_PLACEMENT_NEW(pPlacementAddr) DmaCmdBuffer(*this, createInfo);
     }
+#endif
 
     return result;
 }

--- a/src/core/hw/gfxip/gfx9/gfx9GraphicsPipeline.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9GraphicsPipeline.cpp
@@ -1399,7 +1399,7 @@ void GraphicsPipeline::SetupNonShaderRegisters(
 
     if (m_signature.uavExportTableAddr != UserDataNotMapped)
     {
-#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 497
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 497 && PAL_BUILD_GFX10
         m_uavExportRequiresFlush = (createInfo.cbState.uavExportSingleDraw == false);
 #else
         m_uavExportRequiresFlush = true;

--- a/src/core/imported/addrlib/src/core/addrlib.cpp
+++ b/src/core/imported/addrlib/src/core/addrlib.cpp
@@ -189,7 +189,9 @@ ADDR_E_RETURNCODE Lib::Create(
                         pLib = Gfx9HwlInit(&client);
                         break;
                     case FAMILY_NV:
+#if LLPC_BUILD_GFX10
                         pLib = Gfx10HwlInit(&client);
+#endif
                         break;
 
                     default:


### PR DESCRIPTION
This adds extra guards around code that is only valid when building with
GFX10 enabled.

Tested with GFX10 support disabled and GFX10 support enabled.

Note that this requires changes in the other drivers as well.