### PR TITLE
Add additional resets in BeginCommandStream

### DIFF
--- a/src/core/hw/gfxip/gfxCmdBuffer.cpp
+++ b/src/core/hw/gfxip/gfxCmdBuffer.cpp
@@ -275,6 +275,8 @@ Result GfxCmdBuffer::BeginCommandStreams(
     if (doReset)
     {
         ReturnGeneratedCommandChunks(true);
+        ResetFastClearReferenceCounts();
+        m_releaseActivityMap.Reset();
     }
 
     Result result = CmdBuffer::BeginCommandStreams(cmdStreamFlags, doReset);


### PR DESCRIPTION
This is required to fix unbounded memory growth for reused command
buffers with implicit reset in some cases.

resolves #34 