### PR TITLE
Fixes for HDR support.

### DIFF
--- a/src/core/os/amdgpu/amdgpuDevice.cpp
+++ b/src/core/os/amdgpu/amdgpuDevice.cpp
@@ -5592,12 +5592,14 @@ Result Device::GetHdrMetaData(
 // =====================================================================================================================
 // Set HDR metadata and "max bpc" 10 to enable the HDR display pipeline.
 Result Device::SetHdrMetaData(
+    int32              drmMasterFd,
     uint32             connectorId,
     HdrOutputMetadata* pHdrMetaData
     ) const
 {
     uint32                     blobId = 0;
-    drmModeObjectPropertiesPtr pProps = m_drmProcs.pfnDrmModeObjectGetProperties(m_primaryFileDescriptor,
+    int32 drmFd = (drmMasterFd != InvalidFd) ? drmMasterFd : m_primaryFileDescriptor;
+    drmModeObjectPropertiesPtr pProps = m_drmProcs.pfnDrmModeObjectGetProperties(drmFd,
                                                                                  connectorId,
                                                                                  DRM_MODE_OBJECT_CONNECTOR);
 
@@ -5606,7 +5608,7 @@ Result Device::SetHdrMetaData(
     bool maxBpcSet   = false;
     bool metaDataSet = false;
 
-    Result result = CheckResult(m_drmProcs.pfnDrmModeCreatePropertyBlob(m_primaryFileDescriptor,
+    Result result = CheckResult(m_drmProcs.pfnDrmModeCreatePropertyBlob(drmFd,
                                                                         reinterpret_cast<void*>(pHdrMetaData),
                                                                         sizeof(*pHdrMetaData),
                                                                         &blobId),
@@ -5621,7 +5623,7 @@ Result Device::SetHdrMetaData(
     {
         uint32             propId    = pProps->props[i];
         uint64             propValue = pProps->prop_values[i];
-        drmModePropertyPtr pProp     = m_drmProcs.pfnDrmModeGetProperty(m_primaryFileDescriptor, propId);
+        drmModePropertyPtr pProp     = m_drmProcs.pfnDrmModeGetProperty(drmFd, propId);
 
         if (pProp == nullptr)
         {
@@ -5649,7 +5651,8 @@ Result Device::SetHdrMetaData(
 
     if ((result == Result::Success) && maxBpcSet && metaDataSet)
     {
-        result = CheckResult(m_drmProcs.pfnDrmModeAtomicCommit(m_primaryFileDescriptor,
+        m_drmProcs.pfnDrmSetClientCap(drmFd, DRM_CLIENT_CAP_ATOMIC, 1);
+        result = CheckResult(m_drmProcs.pfnDrmModeAtomicCommit(drmFd,
                                                                pAtomicRequest,
                                                                DRM_MODE_ATOMIC_ALLOW_MODESET,
                                                                nullptr),
@@ -5662,7 +5665,7 @@ Result Device::SetHdrMetaData(
 
     if (blobId > 0)
     {
-        m_drmProcs.pfnDrmModeDestroyPropertyBlob(m_primaryFileDescriptor, blobId);
+        m_drmProcs.pfnDrmModeDestroyPropertyBlob(drmFd, blobId);
     }
 
     if (pAtomicRequest != nullptr)

--- a/src/core/os/amdgpu/amdgpuDevice.cpp
+++ b/src/core/os/amdgpu/amdgpuDevice.cpp
@@ -5410,10 +5410,10 @@ static PAL_INLINE void GetColorCharacteristicsFromEdid(
     pHdrMetaData->metadata.chromaticityRedY        = BitsToDecimal((pEdid[0x1C] << 2) | ((pEdid[0x19] & 0x30) >> 4));
     pHdrMetaData->metadata.chromaticityGreenX      = BitsToDecimal((pEdid[0x1D] << 2) | ((pEdid[0x19] & 0x0C) >> 2));
     pHdrMetaData->metadata.chromaticityGreenY      = BitsToDecimal((pEdid[0x1E] << 2) | (pEdid[0x19] & 0x03));
-    pHdrMetaData->metadata.chromaticityBlueX       = BitsToDecimal((pEdid[0x1F] << 2) | ((pEdid[0x19] & 0xC0) >> 6));
-    pHdrMetaData->metadata.chromaticityBlueY       = BitsToDecimal((pEdid[0x20] << 2) | ((pEdid[0x19] & 0x03) >> 4));
-    pHdrMetaData->metadata.chromaticityWhitePointX = BitsToDecimal((pEdid[0x21] << 2) | ((pEdid[0x19] & 0xC0) >> 2));
-    pHdrMetaData->metadata.chromaticityWhitePointY = BitsToDecimal((pEdid[0x22] << 2) | (pEdid[0x19] & 0x0C));
+    pHdrMetaData->metadata.chromaticityBlueX       = BitsToDecimal((pEdid[0x1F] << 2) | ((pEdid[0x1A] & 0xC0) >> 6));
+    pHdrMetaData->metadata.chromaticityBlueY       = BitsToDecimal((pEdid[0x20] << 2) | ((pEdid[0x1A] & 0x30) >> 4));
+    pHdrMetaData->metadata.chromaticityWhitePointX = BitsToDecimal((pEdid[0x21] << 2) | ((pEdid[0x1A] & 0x0C) >> 2));
+    pHdrMetaData->metadata.chromaticityWhitePointY = BitsToDecimal((pEdid[0x22] << 2) | (pEdid[0x1A] & 0x03));
 
     return;
 }
@@ -5572,6 +5572,7 @@ Result Device::GetHdrMetaData(
             if (result == Result::Success)
             {
                 GetColorCharacteristicsFromEdid(reinterpret_cast<uint8*>(pBlob->data), pHdrMetaData);
+                connectorSupportHdr = true;
             }
 
             m_drmProcs.pfnDrmModeFreePropertyBlob(pBlob);

--- a/src/core/os/amdgpu/amdgpuDevice.h
+++ b/src/core/os/amdgpu/amdgpuDevice.h
@@ -779,6 +779,7 @@ public:
         HdrOutputMetadata* pHdrMetaData) const;
 
     Result SetHdrMetaData(
+        int32              drmMasterFd,
         uint32             connectorId,
         HdrOutputMetadata* pHdrMetaData) const;
 

--- a/src/core/os/amdgpu/amdgpuScreen.cpp
+++ b/src/core/os/amdgpu/amdgpuScreen.cpp
@@ -62,14 +62,14 @@ Screen::Screen(
 void Screen::Destroy()
 {
     // Restore to SDR, unless already in SDR mode.
-    if (m_userColorGamut.metadata.eotf == HDMI_EOTF_TRADITIONAL_GAMMA_SDR)
-        return;
+    if (m_userColorGamut.metadata.eotf != HDMI_EOTF_TRADITIONAL_GAMMA_SDR)
+    {
+        m_userColorGamut.metadataType          = HDMI_STATIC_METADATA_TYPE1;
+        m_userColorGamut.metadata.eotf         = HDMI_EOTF_TRADITIONAL_GAMMA_SDR;
+        m_userColorGamut.metadata.metadataType = HDMI_STATIC_METADATA_TYPE1;
 
-    m_userColorGamut.metadataType          = HDMI_STATIC_METADATA_TYPE1;
-    m_userColorGamut.metadata.eotf         = HDMI_EOTF_TRADITIONAL_GAMMA_SDR;
-    m_userColorGamut.metadata.metadataType = HDMI_STATIC_METADATA_TYPE1;
-
-    static_cast<Device*>(m_pDevice)->SetHdrMetaData(m_drmMasterFd, m_connectorId, &m_userColorGamut);
+        static_cast<Device*>(m_pDevice)->SetHdrMetaData(m_drmMasterFd, m_connectorId, &m_userColorGamut);
+    }
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
This pull contains bug fixes and improvements for HDR support to make HDR actually usable for desktop applications, which will generally run under X11 and not directly on a VT DRM framebuffer.

1. Fix the EDID parsing wrt. HDR display capabilities.

2. Make HDR work with X11 RandR leased video outputs in direct display mode.

Please consider these fixes for a release soon. Thanks.