### PR TITLE
pal: Fix vkGetRandROutputDisplayEXT on repeated calls.

### DIFF
--- a/src/core/os/amdgpu/amdgpuScreen.cpp
+++ b/src/core/os/amdgpu/amdgpuScreen.cpp
@@ -330,7 +330,7 @@ Result Screen::GetRandrOutput(
     OsDisplayHandle hDisplay,
     uint32*         pRandrOutput)
 {
-    Result result = Result::ErrorUnknown;
+    Result result = Result::Success;
 
     if (m_randrOutput == 0)
     {


### PR DESCRIPTION
If vkGetRandROutputDisplayEXT() is called more than once
for the same RandR output, the call fails on 2nd, 3rd,
... invocation with return status code VK_SUCCESS but a
returned NULL VkDisplayKHR handle!

This, because Screen::GetRandrOutput() tries to avoid
redundant calls to WindowSystem::GetOutputFromConnector(),
if m_randrOutput is already != 0, but in this case it
fails to init the return status code result properly.

Fix this by proper init for result.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>