### PR TITLE
Enable usage of PAL headers from Windows when building a standalone amdllpc

### DIFF
--- a/inc/util/palAssert.h
+++ b/inc/util/palAssert.h
@@ -44,6 +44,15 @@
 /// compiles do not currently enable static code analysis.
 #define PAL_ANALYSIS_ASSUME(expr)
 
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(_WIN64)
+
+/// OS-independent macro to force a break into the debugger.
+#define PAL_DEBUG_BREAK() __debugbreak();
+
+/// OS-independent macro to direct static code analysis to assume the specified expression will always be true.  Linux
+/// compiles do not currently enable static code analysis.
+#define PAL_ANALYSIS_ASSUME(expr)
+
 #endif
 
 #if PAL_ENABLE_PRINTS_ASSERTS

--- a/inc/util/palUtil.h
+++ b/inc/util/palUtil.h
@@ -59,6 +59,21 @@
 #define PAL_ALIGN(__x)
 #define PAL_FORCE_INLINE __attribute__((always_inline)) inline
 #define PAL_WEAK_LINK __attribute__((weak))
+#elif defined(_MSC_VER)
+/// Undefined on GCC platforms.
+#define PAL_STDCALL __stdcall
+/// Undefined on GCC platforms.
+#define PAL_CDECL __cdecl
+/// Undefined on GCC platforms.
+#define PAL_NO_RETURN __declspec(noreturn)
+/// Undefined on GCC platforms.
+#define PAL_ALIGN(__x) __declspec(align(__x))
+#define PAL_FORCE_INLINE __forceinline
+#define PAL_WEAK_LINK __declspec(selectany)
+PAL_FORCE_INLINE int strcasecmp(const char* s1, const char* s2)
+{
+    return _stricmp(s1, s2);
+}
 #else
 #error "Unsupported OS platform detected!"
 #endif


### PR DESCRIPTION
I'm building amdllpc as a stand-alone tool on Windows for educational purposes. These minor preprocessor compiler branch implementations enable the code to compile with MSVC and for Windows.