### PR TITLE
pal: Fix GetColorCharacteristicsFromEdid again for xgl compatiblity.

### DIFF
--- a/src/core/os/amdgpu/amdgpuDevice.cpp
+++ b/src/core/os/amdgpu/amdgpuDevice.cpp
@@ -5509,7 +5509,7 @@ static PAL_INLINE uint8* GetCeaExtensionBlock(
 }
 
 // =====================================================================================================================
-// Helper function to convert binary to decimal and mulitply 10000
+// Helper function to convert binary to decimal and multiply by 50000
 static PAL_INLINE uint32 BitsToDecimal(
     uint32 value)
 {
@@ -5524,7 +5524,7 @@ static PAL_INLINE uint32 BitsToDecimal(
         }
     }
 
-    return result * 10000;
+    return result * 50000;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
In xgl at commit 1f6143fb951622e06fe7b9396957976fc9feddc7
the implementation of PhysicalDevice::GetSurfaceCapabilities2KHR()
was modified to scale color gamut chroma coordinates provided by
PAl with a scaling factor of 1.0/50000.0 instead of the old scaling
factor 1.0/10000.0.

This causes all reported HDR display gamut chromaticity coordinates
to be a factor 5 too small, and unsurprisingly this breaks proper
HDR on Linux again.

To fix this problem, modify pal to multiply returned chromaticity
coordinates by 50000 instead of the old multiplier of 10000.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>