### PR TITLE
pal: Add support for displayable fp16 swapchain format.

### DIFF
--- a/src/core/os/amdgpu/amdgpuDevice.cpp
+++ b/src/core/os/amdgpu/amdgpuDevice.cpp
@@ -5762,8 +5762,12 @@ Result Device::SetHdrMetaData(
 
         if (strcmp(pProp->name, "max bpc") == 0)
         {
-            result = (m_drmProcs.pfnDrmModeAtomicAddProperty(pAtomicRequest, connectorId, propId, 10) < 0) ?
-                        Result::ErrorInvalidValue : Result::Success;
+            // Increase "max bpc" to at least 10 bits, as needed by HDR-10, if the current limit is lower.
+            if (propValue < 10)
+            {
+                result = (m_drmProcs.pfnDrmModeAtomicAddProperty(pAtomicRequest, connectorId, propId, 10) < 0) ?
+                            Result::ErrorInvalidValue : Result::Success;
+            }
 
             maxBpcSet = true;
         }

--- a/src/core/os/amdgpu/amdgpuDevice.h
+++ b/src/core/os/amdgpu/amdgpuDevice.h
@@ -843,6 +843,8 @@ private:
         uint32    kernelMinorVer
         ) const;
 
+    bool HasFp16DisplaySupport();
+
     void CheckSyncObjectSupportStatus();
 
     Result InitGpuProperties();

--- a/src/core/os/amdgpu/amdgpuScreen.cpp
+++ b/src/core/os/amdgpu/amdgpuScreen.cpp
@@ -122,33 +122,21 @@ Result Screen::GetScreenModeList(
                                                                          pScreenModeList);
 }
 
-const SwizzledFormat PresentableSwizzledFormat[] =
-{
-    {
-        ChNumFormat::X8Y8Z8W8_Unorm,
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W }
-    },
-    {
-        ChNumFormat::X8Y8Z8W8_Srgb,
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W }
-    },
-    {
-        ChNumFormat::X10Y10Z10W2_Unorm,
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W }
-    },
-    {
-        ChNumFormat::X10Y10Z10W2_Unorm,
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W }
-    },
-};
-
 // =====================================================================================================================
 Result Screen::GetFormats(
     uint32*          pFormatCount,
     SwizzledFormat*  pFormatList)
 {
-    Result result      = Result::Success;
-    uint32 formatCount = sizeof(PresentableSwizzledFormat) / sizeof(PresentableSwizzledFormat[0]);
+    Result result;
+    uint32 formatCount                      = 0;
+    SwapChainProperties swapChainProperties = {};
+
+    result = static_cast<Device*>(m_pDevice)->GetSwapChainInfo((OsDisplayHandle) nullptr, NullWindowHandle,
+                                                               WsiPlatform::DirectDisplay, &swapChainProperties);
+    if (result == Result::Success)
+    {
+        formatCount = swapChainProperties.imageFormatCount;
+    }
 
     PAL_ASSERT(((pFormatCount != nullptr) && (pFormatList != nullptr)) ||
                ((pFormatList == nullptr) && (pFormatCount != nullptr)));
@@ -163,7 +151,7 @@ Result Screen::GetFormats(
 
         for (uint32 i = 0; i < returnedFormat; i++)
         {
-            pFormatList[i] = PresentableSwizzledFormat[i];
+            pFormatList[i] = swapChainProperties.imageFormat[i];
         }
 
         if (returnedFormat < formatCount)

--- a/src/core/os/amdgpu/display/displayWindowSystem.cpp
+++ b/src/core/os/amdgpu/display/displayWindowSystem.cpp
@@ -70,6 +70,10 @@ static uint32 PalToDrmFormat(
 
             break;
 
+        case ChNumFormat::X16Y16Z16W16_Float:
+            drmFormat = DRM_FORMAT_XBGR16161616F;
+            break;
+
         default:
             PAL_ASSERT(!"Not supported format!");
             break;
@@ -285,7 +289,7 @@ Result DisplayWindowSystem::CreatePresentableImage(
             pImage->SetPresentImageHandle(imageHandle);
 
             FindCrtc();
-            ModeSet(pImage);
+            ret = ModeSet(pImage) != Result::Success;
         }
     }
 


### PR DESCRIPTION
Maps VK_FORMAT_R16_G16_B16_A16_SFLOAT to amdgpu-kms format
DRM_FORMAT_XBGR16161616F. Linux 5.8 amdgpu-kms supports
this format for scanout and display on gpu's with DCE-11.2
display engine (Polaris family) and later generations.

Linux kernel 5.8 mainline commit for this new feature is
2a5195dca0b7058e65443416a20680be985d8753
("drm/amd/display: Expose support for xBGR ordered fp16 formats.")

Successfully tested on Polaris DCE-11.2 and Raven Ridge DCN-1.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>