### PR TITLE
pal: Emulate 32-bit predication on the universal engine

### DIFF
--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -1920,7 +1920,8 @@ Result Device::GetProperties(
 
             pEngineInfo->flags.supportsTimestamps              = engineInfo.flags.timestampSupport;
             pEngineInfo->flags.supportsQueryPredication        = engineInfo.flags.queryPredicationSupport;
-            pEngineInfo->flags.supports32bitMemoryPredication  = engineInfo.flags.memory32bPredicationSupport;
+            pEngineInfo->flags.supports32bitMemoryPredication  = engineInfo.flags.memory32bPredicationSupport ||
+                                                                 engineInfo.flags.memory32bPredicationEmulated;
             pEngineInfo->flags.supports64bitMemoryPredication  = engineInfo.flags.memory64bPredicationSupport;
             pEngineInfo->flags.supportsConditionalExecution    = engineInfo.flags.conditionalExecutionSupport;
             pEngineInfo->flags.supportsLoopExecution           = engineInfo.flags.loopExecutionSupport;

--- a/src/core/device.h
+++ b/src/core/device.h
@@ -412,7 +412,8 @@ struct GpuEngineProperties
                 uint32 mustUseSvmIfSupported           :  1;
                 uint32 supportsTrackBusyChunks         :  1;
                 uint32 supportsUnmappedPrtPageAccess   :  1;
-                uint32 reserved                        :  9;
+                uint32 memory32bPredicationEmulated    :  1;
+                uint32 reserved                        :  8;
             };
             uint32 u32All;
         } flags;

--- a/src/core/hw/gfxip/gfx9/gfx9CmdUtil.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9CmdUtil.cpp
@@ -3270,6 +3270,8 @@ size_t CmdUtil::BuildSetPredication(
 
     // The predication memory address must be 16-byte aligned, and cannot be wider than 40 bits.
     PAL_ASSERT(((gpuVirtAddr & 0xF) == 0) && (gpuVirtAddr <= ((1uLL << 40) - 1)));
+    // The predicate type has to be valid.
+    PAL_ASSERT(predType < PredicateType::Boolean32);
 
     pPacket->ordinal1.header.u32All = Type3Header(IT_SET_PREDICATION, PacketSize);
     pPacket->ordinal3.u32All        = LowPart(gpuVirtAddr);

--- a/src/core/hw/gfxip/gfx9/gfx9Device.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9Device.cpp
@@ -4478,6 +4478,7 @@ void InitializeGpuEngineProperties(
     pUniversal->flags.timestampSupport                = 1;
     pUniversal->flags.borderColorPaletteSupport       = 1;
     pUniversal->flags.queryPredicationSupport         = 1;
+    pUniversal->flags.memory32bPredicationSupport     = 1; // Emulated by embedding a 64-bit predicate in the cmdbuf and copying from the 32-bit source.
     pUniversal->flags.memory64bPredicationSupport     = 1;
     pUniversal->flags.conditionalExecutionSupport     = 1;
     pUniversal->flags.loopExecutionSupport            = 1;

--- a/src/core/hw/gfxip/gfx9/gfx9Device.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9Device.cpp
@@ -4478,7 +4478,7 @@ void InitializeGpuEngineProperties(
     pUniversal->flags.timestampSupport                = 1;
     pUniversal->flags.borderColorPaletteSupport       = 1;
     pUniversal->flags.queryPredicationSupport         = 1;
-    pUniversal->flags.memory32bPredicationSupport     = 1; // Emulated by embedding a 64-bit predicate in the cmdbuf and copying from the 32-bit source.
+    pUniversal->flags.memory32bPredicationEmulated    = 1; // Emulated by embedding a 64-bit predicate in the cmdbuf and copying from the 32-bit source.
     pUniversal->flags.memory64bPredicationSupport     = 1;
     pUniversal->flags.conditionalExecutionSupport     = 1;
     pUniversal->flags.loopExecutionSupport            = 1;


### PR DESCRIPTION
The PFP only supports 64-bit predicates (which is what DX12 specs),
whereas Vulkan specs 32b-bit predicates. AMD never resolved that
mismatch, but implemented the rest of EXT_conditional_rendering anyways,
with an appropriate check for 32-bit predication support.

This patch emulates 32-bit predication on the universal engine by
allocating a scratch 64-bit predicate in command buffer embedded data
memory and emitting a ME copy from the original 32-bit predicate to the
lower 32 bits of that scratch predicate, prior to emitting the
SET_PREDICATION command.

Testing:
Run https://github.com/SaschaWillems/Vulkan/tree/master/examples/conditionalrender