### PR TITLE
Restore full 24 or 16 bit depth buffer precision on gfx6/9

### DIFF
--- a/src/core/hw/gfxip/gfx6/gfx6DepthStencilView.cpp
+++ b/src/core/hw/gfxip/gfx6/gfx6DepthStencilView.cpp
@@ -299,7 +299,7 @@ void DepthStencilView::InitRegisters(
         // NOTE: The client has indicated this Image has promoted 24bit depth to 32bits, we should set the negative num
         // bit as -24 and use fixed points format
         m_regs.paSuPolyOffsetDbFmtCntl.bits.POLY_OFFSET_NEG_NUM_DB_BITS =
-            (imageCreateInfo.usageFlags.depthAsZ24 == 1) ? -22 : ((m_regs.dbZInfo.bits.FORMAT == Z_16) ? -15 : -23);
+            (imageCreateInfo.usageFlags.depthAsZ24 == 1) ? -24 : ((m_regs.dbZInfo.bits.FORMAT == Z_16) ? -16 : -23);
         m_regs.paSuPolyOffsetDbFmtCntl.bits.POLY_OFFSET_DB_IS_FLOAT_FMT =
             ((m_regs.dbZInfo.bits.FORMAT == Z_32_FLOAT) && (imageCreateInfo.usageFlags.depthAsZ24 == 0)) ? 1 : 0;
     }

--- a/src/core/hw/gfxip/gfx9/gfx9DepthStencilView.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9DepthStencilView.cpp
@@ -285,7 +285,7 @@ void DepthStencilView::InitRegistersCommon(
         // NOTE: The client has indicated this Image has promoted 24bit depth to 32bits, we should set the negative num
         //       bit as -24 and use fixed points format
         pRegs->paSuPolyOffsetDbFmtCntl.bits.POLY_OFFSET_NEG_NUM_DB_BITS =
-            (imageCreateInfo.usageFlags.depthAsZ24 == 1) ? -22 : ((pRegs->dbZInfo.bits.FORMAT == Z_16) ? -15 : -23);
+            (imageCreateInfo.usageFlags.depthAsZ24 == 1) ? -24 : ((pRegs->dbZInfo.bits.FORMAT == Z_16) ? -16 : -23);
         pRegs->paSuPolyOffsetDbFmtCntl.bits.POLY_OFFSET_DB_IS_FLOAT_FMT =
             ((pRegs->dbZInfo.bits.FORMAT == Z_32_FLOAT) && (imageCreateInfo.usageFlags.depthAsZ24 == 0)) ? 1 : 0;
     }


### PR DESCRIPTION
The lowered precision of 22 or 15 bits reduces overall visual
quality of scenes with shadow maps, even if rounding may be
more accurate with fewer bits. This change restores the full
24 or 16 bits for UNORM depth buffers.

Tested by running examples and confirming the results look more natural
and match previous renders. See
https://github.com/SaschaWillems/Vulkan/blob/master/examples/shadowmapping/shadowmapping.cpp
for an example scene that has reduced quality with a 15 bit depth buffer. This example uses a depth bias of 1.25f, possibly to avoid the rounding issue