### PR TITLE
Expose system filename length limits in palArchiveFile

### DIFF
--- a/inc/core/palLib.h
+++ b/inc/core/palLib.h
@@ -43,7 +43,7 @@
 ///            compatible, it is not assumed that the client will initialize all input structs to 0.
 ///
 /// @ingroup LibInit
-#define PAL_INTERFACE_MAJOR_VERSION 636
+#define PAL_INTERFACE_MAJOR_VERSION 639
 
 /// Minor interface version.  Note that the interface version is distinct from the PAL version itself, which is returned
 /// in @ref Pal::PlatformProperties.

--- a/src/util/lnx/lnxArchiveFile.cpp
+++ b/src/util/lnx/lnxArchiveFile.cpp
@@ -58,9 +58,17 @@ static char* GenerateFullPath(
     PAL_ASSERT(pOpenInfo        != nullptr);
     PAL_ASSERT(stringBufferSize != 0);
 
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
     Strncpy(pStringBuffer, pOpenInfo->filePath, stringBufferSize);
+#else
+    Strncpy(pStringBuffer, pOpenInfo->pFilePath, stringBufferSize);
+#endif
     Strncat(pStringBuffer, stringBufferSize, "/");
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
     Strncat(pStringBuffer, stringBufferSize, pOpenInfo->fileName);
+#else
+    Strncat(pStringBuffer, stringBufferSize, pOpenInfo->pFileName);
+#endif
 
     return pStringBuffer;
 }
@@ -207,10 +215,14 @@ static Result CreateDir(
     const char *pPathName)
 {
     Result result = Result::Success;
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
     char dirName[MaxPathLength];
+#else
+    char dirName[PathBufferLen];
+#endif
 
-    Strncpy(dirName, pPathName, MaxPathLength);
-    Strncat(dirName, MaxPathLength, "/");
+    Strncpy(dirName, pPathName, sizeof(dirName));
+    Strncat(dirName, sizeof(dirName), "/");
 
     const uint32 len = strlen(dirName);
 
@@ -243,7 +255,11 @@ static Result CreateFileInternal(
     PAL_ASSERT(pFileName != nullptr);
     PAL_ASSERT(pOpenInfo != nullptr);
 
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
     Result result = CreateDir(pOpenInfo->filePath);
+#else
+    Result result = CreateDir(pOpenInfo->pFilePath);
+#endif
 
     if (result == Result::Success)
     {
@@ -1155,7 +1171,11 @@ Result OpenArchiveFile(
     }
 
     int32  hFile = InvalidFd;
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
     char   stringBuffer[MaxPathLength + MaxFilenameLength + 1] = {};
+#else
+    char   stringBuffer[PathBufferLen] = {};
+#endif
 
     GenerateFullPath(stringBuffer, sizeof(stringBuffer), pOpenInfo);
     if (result == Result::Success)
@@ -1246,7 +1266,11 @@ Result CreateArchiveFile(
 
     if (pOpenInfo != nullptr)
     {
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
         char stringBuffer[MaxPathLength + MaxFilenameLength + 1] = {};
+#else
+        char stringBuffer[PathBufferLen] = {};
+#endif
         GenerateFullPath(stringBuffer, sizeof(stringBuffer), pOpenInfo);
         result = CreateFileInternal(stringBuffer, pOpenInfo);
     }
@@ -1265,7 +1289,11 @@ Result DeleteArchiveFile(
 
     if (pOpenInfo != nullptr)
     {
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 639
         char stringBuffer[MaxPathLength + MaxFilenameLength + 1] = {};
+#else
+        char stringBuffer[PathBufferLen] = {};
+#endif
         GenerateFullPath(stringBuffer, sizeof(stringBuffer), pOpenInfo);
         if (remove(stringBuffer) == InvalidSysCall)
         {


### PR DESCRIPTION
The previous limits were insufficient for long paths and duplicated in
XGL's pipeline_binary_cache.

Related XGL change: https://github.com/GPUOpen-Drivers/xgl/pull/65.