### PR TITLE
Fix custom operator new for clang with noexcept

### DIFF
--- a/src/core/imported/addrlib/src/core/addrobject.cpp
+++ b/src/core/imported/addrlib/src/core/addrobject.cpp
@@ -177,6 +177,7 @@ VOID Object::Free(
 VOID* Object::operator new(
     size_t objSize,     ///< [in] Size to allocate
     VOID*  pMem)        ///< [in] Pre-allocated pointer
+    noexcept
 {
     return pMem;
 }

--- a/src/core/imported/addrlib/src/core/addrobject.h
+++ b/src/core/imported/addrlib/src/core/addrobject.h
@@ -61,7 +61,7 @@ public:
     Object(const Client* pClient);
     virtual ~Object();
 
-    VOID* operator new(size_t size, VOID* pMem);
+    VOID* operator new(size_t size, VOID* pMem) noexcept;
     VOID  operator delete(VOID* pObj);
     /// Microsoft compiler requires a matching delete implementation, which seems to be called when
     /// bad_alloc is thrown. But currently C++ exception isn't allowed so a dummy implementation is
@@ -91,4 +91,3 @@ private:
 
 } // Addr
 #endif
-

--- a/src/core/imported/vam/src/core/vamobject.cpp
+++ b/src/core/imported/vam/src/core/vamobject.cpp
@@ -87,6 +87,7 @@ VamObject::~VamObject()
 VOID* VamObject::operator new(
     size_t              objSize,    ///< [in] Size to allocate
     VAM_CLIENT_HANDLE   hClient)    ///< [in] Client handle
+    noexcept
 {
     VOID* pObjMem = NULL;
 

--- a/src/core/imported/vam/src/core/vamobject.h
+++ b/src/core/imported/vam/src/core/vamobject.h
@@ -47,7 +47,7 @@ public:
     VamObject(VAM_CLIENT_HANDLE hClient);
     virtual ~VamObject();
 
-    VOID* operator new(size_t size, VAM_CLIENT_HANDLE hClient);
+    VOID* operator new(size_t size, VAM_CLIENT_HANDLE hClient) noexcept;
     VOID  operator delete(VOID* pObj, VAM_CLIENT_HANDLE hClient);
     VOID  operator delete(VOID* pObj);
 


### PR DESCRIPTION
clang ignores gcc's -fcheck-new flag, which means that the few custom
operator new implementations in AMDVLK did not handle OOM conditions
properly and invoked constructors with null this pointers. But
fortunately, all of theose operators are custom user operators, by
virtue of using a custom third argument. Consequently, they are allowed
to be noexcept, which will force the compiler to emit a null check. This
is a better fix than using -fcheck-new and will work with any standard
C++ compiler.