### PR TITLE
Fix ordering of RGP image layout markers

### DIFF
--- a/src/core/hw/gfxip/gfx9/gfx9AcquireReleaseBarrier.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9AcquireReleaseBarrier.cpp
@@ -403,8 +403,7 @@ bool Device::AcqRelInitMaskRam(
                                                        pCmdStream,
                                                        gfx9Image,
                                                        subresRange,
-                                                       imgBarrier.newLayout,
-                                                       nullptr);
+                                                       imgBarrier.newLayout);
 
     return usedCompute;
 }

--- a/src/core/hw/gfxip/gfx9/gfx9Barrier.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9Barrier.cpp
@@ -1515,8 +1515,7 @@ void Device::Barrier(
                                                                            pCmdStream,
                                                                            gfx9Image,
                                                                            subresRange,
-                                                                           imageInfo.newLayout,
-                                                                           nullptr);
+                                                                           imageInfo.newLayout);
 
                         // After initializing Mask RAM, we need some syncs to guarantee the initialization blts have
                         // finished, even if other Blts caused these operations to occur before any Blts were performed.

--- a/src/core/hw/gfxip/rpm/gfx9/gfx9RsrcProcMgr.cpp
+++ b/src/core/hw/gfxip/rpm/gfx9/gfx9RsrcProcMgr.cpp
@@ -863,17 +863,11 @@ bool RsrcProcMgr::InitMaskRam(
     Pal::CmdStream*               pCmdStream,
     const Image&                  dstImage,
     const SubresRange&            range,
-    ImageLayout                   layout,
-    Developer::BarrierOperations* pBarrierOps
+    ImageLayout                   layout
     ) const
 {
     const auto&       settings   = GetGfx9Settings(*dstImage.Parent()->GetDevice());
     const Pal::Image* pParentImg = dstImage.Parent();
-
-    if (pBarrierOps != nullptr)
-    {
-        pBarrierOps->layoutTransitions.initMaskRam = 1;
-    }
 
     // If we're in this function, we know this surface has meta-data.  Most of the meta-data init functions use compute
     // so assume that by default.
@@ -1011,11 +1005,6 @@ bool RsrcProcMgr::InitMaskRam(
         // We need to initialize the Image's DCC state metadata to indicate that the Image can become DCC compressed
         // (or not) in upcoming operations.
         const bool canCompress = ImageLayoutCanCompressColorData(dstImage.LayoutToColorCompressionState(), layout);
-
-        if (pBarrierOps != nullptr)
-        {
-            pBarrierOps->layoutTransitions.updateDccStateMetadata = 1;
-        }
 
         // If the new layout is one which can write compressed DCC data,  then we need to update the Image's DCC state
         // metadata to indicate that the image will become DCC compressed in upcoming operations.

--- a/src/core/hw/gfxip/rpm/gfx9/gfx9RsrcProcMgr.h
+++ b/src/core/hw/gfxip/rpm/gfx9/gfx9RsrcProcMgr.h
@@ -110,8 +110,7 @@ public:
         Pal::CmdStream*               pCmdStream,
         const Image&                  dstImage,
         const SubresRange&            range,
-        ImageLayout                   layout,
-        Developer::BarrierOperations* pBarrierOps) const;
+        ImageLayout                   layout) const;
 
     void BuildHtileLookupTable(
         GfxCmdBuffer*      pCmdBuffer,


### PR DESCRIPTION
In every other case, `DescribeBarrier` is called first (recording the layout transition marker for RGP), followed by the recording of the
actual layout transition events. In this case, `DescribeBarrier` is called *after* `InitMaskRam`, so the layout transition marker comes
after the corresponding events.

In RGP, this causes layout transitions to show up incorrectly. For example, I have a capture with a RenderPassSync barrier that should have 3 `InitMaskRam` layout transitions. In the raw RGP markers, I see:

1. BarrierStart
2. Event
3. LayoutTransition
4. Event
5. LayoutTransition
6. Event
7. LayoutTransition
8. BarrierEnd

In RGP, this is rendered as **two** barriers ("0 CmdRenderPassSync" and "1 CmdDispatch"). **Both** of these barriers are shown having the **same** two layout transitions ("2 CmdInitMaskRam" and "3 CmdInitMaskRam"). Here is an image of this barrier in RGP:

> ![layout-transition-event-rgp-small](https://user-images.githubusercontent.com/1546096/102273654-a9656600-3ef0-11eb-87d0-0c50ff08c7ef.png)


Re-capturing with this PR, RGP shows a single barrier ("0 CmdRenderPassSync"), with three layout transitions, as expected:
> ![layout-transition-event-rgp-fixed-small](https://user-images.githubusercontent.com/1546096/102273669-b08c7400-3ef0-11eb-927f-93ee4aa0ee0c.png)