### PR TITLE
Use external synchronization for multi process shared memory

### DIFF
--- a/inc/core/palGpuMemory.h
+++ b/inc/core/palGpuMemory.h
@@ -160,7 +160,8 @@ union GpuMemoryCreateFlags
         uint32 placeholder1      :  1; ///< Reserved for future HW.
 #endif
 #if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
-        uint32 explicitSync      :  1;
+        uint32 explicitSync      :  1; ///< If set, shared memory will skip syncs in the kernel and all drivers
+                                       ///  that use this memory must handle syncs explicitly.
 #else
         uint32 placeholder657    :  1;
 #endif

--- a/inc/core/palGpuMemory.h
+++ b/inc/core/palGpuMemory.h
@@ -159,8 +159,12 @@ union GpuMemoryCreateFlags
 #else
         uint32 placeholder1      :  1; ///< Reserved for future HW.
 #endif
-
-        uint32 reserved          :  6; ///< Reserved for future use.
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
+        uint32 explicitSync      :  1;
+#else
+        uint32 placeholder657    :  1;
+#endif
+        uint32 reserved          :  5; ///< Reserved for future use.
     };
     uint32     u32All;                 ///< Flags packed as 32-bit uint.
 };

--- a/inc/core/palLib.h
+++ b/inc/core/palLib.h
@@ -53,7 +53,7 @@
 /// of the existing enum values will change.  This number will be reset to 0 when the major version is incremented.
 ///
 /// @ingroup LibInit
-#define PAL_INTERFACE_MINOR_VERSION 4
+#define PAL_INTERFACE_MINOR_VERSION 0
 
 /// Minimum major interface version. This is the minimum interface version PAL supports in order to support backward
 /// compatibility. When it is equal to PAL_INTERFACE_MAJOR_VERSION, only the latest interface version is supported.

--- a/inc/core/palLib.h
+++ b/inc/core/palLib.h
@@ -43,7 +43,7 @@
 ///            compatible, it is not assumed that the client will initialize all input structs to 0.
 ///
 /// @ingroup LibInit
-#define PAL_INTERFACE_MAJOR_VERSION 656
+#define PAL_INTERFACE_MAJOR_VERSION 657
 
 /// Minor interface version.  Note that the interface version is distinct from the PAL version itself, which is returned
 /// in @ref Pal::PlatformProperties.

--- a/src/core/gpuMemory.cpp
+++ b/src/core/gpuMemory.cpp
@@ -402,6 +402,9 @@ Result GpuMemory::Init(
 #if ( (PAL_CLIENT_INTERFACE_MAJOR_VERSION>= 569))
     m_flags.mallRangeActive      = createInfo.flags.mallRangeActive;
 #endif
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
+    m_flags.explicitSync         = createInfo.flags.explicitSync;
+#endif
 
     m_flags.isClient             = internalInfo.flags.isClient;
     m_flags.pageDirectory        = internalInfo.flags.pageDirectory;

--- a/src/core/gpuMemory.h
+++ b/src/core/gpuMemory.h
@@ -163,7 +163,12 @@ union GpuMemoryFlags
 #else
         uint32 placeholder1             :  1;
 #endif
-        uint32 reserved                 : 23;
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
+        uint32 explicitSync             :  1;
+#else
+        uint32 placeholder657           :  1;
+#endif
+        uint32 reserved                 : 22;
     };
     uint64  u64All;
 };
@@ -275,6 +280,9 @@ public:
     bool IsAccessedPhysically()  const { return (m_flags.accessedPhysically       != 0); }
 #if ( (PAL_CLIENT_INTERFACE_MAJOR_VERSION>= 569))
     bool IsMallRangeActive()     const { return (m_flags.mallRangeActive          != 0); }
+#endif
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
+    bool IsExplicitSync()        const { return (m_flags.explicitSync             != 0); }
 #endif
     void SetAccessedPhysically() { m_flags.accessedPhysically = 1; }
     void SetSurfaceBusAddr(gpusize surfaceBusAddr) { m_desc.surfaceBusAddr = surfaceBusAddr; }

--- a/src/core/gpuMemory.h
+++ b/src/core/gpuMemory.h
@@ -163,11 +163,7 @@ union GpuMemoryFlags
 #else
         uint32 placeholder1             :  1;
 #endif
-#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
         uint32 explicitSync             :  1;
-#else
-        uint32 placeholder657           :  1;
-#endif
         uint32 reserved                 : 22;
     };
     uint64  u64All;
@@ -281,9 +277,7 @@ public:
 #if ( (PAL_CLIENT_INTERFACE_MAJOR_VERSION>= 569))
     bool IsMallRangeActive()     const { return (m_flags.mallRangeActive          != 0); }
 #endif
-#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
     bool IsExplicitSync()        const { return (m_flags.explicitSync             != 0); }
-#endif
     void SetAccessedPhysically() { m_flags.accessedPhysically = 1; }
     void SetSurfaceBusAddr(gpusize surfaceBusAddr) { m_desc.surfaceBusAddr = surfaceBusAddr; }
     void SetMarkerBusAddr(gpusize markerBusAddr)   { m_desc.markerBusAddr  = markerBusAddr;  }

--- a/src/core/os/amdgpu/amdgpuGpuMemory.cpp
+++ b/src/core/os/amdgpu/amdgpuGpuMemory.cpp
@@ -360,6 +360,15 @@ Result GpuMemory::AllocateOrPinMemory(
                     m_isVmAlwaysValid = true;
                 }
 
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
+                if (IsExplicitSync() &&
+                   ((m_flags.interprocess == 1) ||
+                    (m_desc.flags.isExternal == 1) ||
+                    (m_flags.isShareable == 1)))
+                {
+                    allocRequest.flags |= AMDGPU_GEM_CREATE_EXPLICIT_SYNC;
+                }
+#endif
                 allocRequest.alloc_size     = m_desc.size;
                 allocRequest.phys_alignment = GetPhysicalAddressAlignment();
 
@@ -619,6 +628,12 @@ Result GpuMemory::OpenSharedMemory(
                     break;
             }
         }
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
+        if (bufferInfo.alloc_flags & AMDGPU_GEM_CREATE_EXPLICIT_SYNC)
+        {
+            m_flags.explicitSync = 1;
+        }
+#endif
     }
     // handle should be closed here otherwise, the memory would never be freed since it takes one extra refcount.
     close(handle);

--- a/src/core/os/amdgpu/amdgpuGpuMemory.cpp
+++ b/src/core/os/amdgpu/amdgpuGpuMemory.cpp
@@ -360,7 +360,6 @@ Result GpuMemory::AllocateOrPinMemory(
                     m_isVmAlwaysValid = true;
                 }
 
-#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
                 if (IsExplicitSync() &&
                    ((m_flags.interprocess == 1) ||
                     (m_desc.flags.isExternal == 1) ||
@@ -368,7 +367,6 @@ Result GpuMemory::AllocateOrPinMemory(
                 {
                     allocRequest.flags |= AMDGPU_GEM_CREATE_EXPLICIT_SYNC;
                 }
-#endif
                 allocRequest.alloc_size     = m_desc.size;
                 allocRequest.phys_alignment = GetPhysicalAddressAlignment();
 
@@ -628,12 +626,10 @@ Result GpuMemory::OpenSharedMemory(
                     break;
             }
         }
-#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 657
         if (bufferInfo.alloc_flags & AMDGPU_GEM_CREATE_EXPLICIT_SYNC)
         {
             m_flags.explicitSync = 1;
         }
-#endif
     }
     // handle should be closed here otherwise, the memory would never be freed since it takes one extra refcount.
     close(handle);


### PR DESCRIPTION
Set the KMD flag to disable implicit synchronization if we are working with multi-process memory.

Resolves #59 