### PR TITLE
pal: Extend displayable fp16 swapchain support to DCE8+.

### DIFF
--- a/src/core/os/amdgpu/amdgpuDevice.cpp
+++ b/src/core/os/amdgpu/amdgpuDevice.cpp
@@ -2093,6 +2093,14 @@ bool Device::HasFp16DisplaySupport()
         supported = true;
     }
 
+    // On Linux 5.12 and later or DRM 3.41 and later we also have the fp16 floating point format
+    // on all display engines since DCE 8.0, ie. additionally on Gfx7-DCE 8.x, Gfx8-10.0/11.0.
+    if ((IsDrmVersionOrGreater(3, 41) || IsKernelVersionEqualOrGreater(5, 12)) &&
+        (IsGfx8(*this) || IsGfx7(*this)))
+    {
+        supported = true;
+    }
+
     return supported;
 }
 


### PR DESCRIPTION
VK_FORMAT_R16G16B16A16_SFLOAT now also gets enabled for
all DCE 8.0 and later display engines.

Linux 5.12 amdgpu-kms DisplayCore supports this format
for scanout and display on all Sea Islands / Gfx7 gpu's
and later with DCE-8.0 display engines and later generations.

Upcoming Linux kernel 5.12 mainline commit for this new
feature is 4b6b7437b19d3116d409e747582c99152725288d
("drm/amd/display: Enable fp16 also on DCE-8/10/11.")

Successfully tested on AMD Mullins DCE-8.3, Polaris DCE-11.2
and Raven Ridge DCN-1.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>