### PR TITLE
Support 32bit predicates on the universal engine on GFX6-8.

### DIFF
--- a/src/core/hw/gfxip/gfx6/gfx6Device.cpp
+++ b/src/core/hw/gfxip/gfx6/gfx6Device.cpp
@@ -3399,6 +3399,7 @@ void InitializeGpuEngineProperties(
     pUniversal->flags.timestampSupport                = 1;
     pUniversal->flags.borderColorPaletteSupport       = 1;
     pUniversal->flags.queryPredicationSupport         = 1;
+    pUniversal->flags.memory32bPredicationEmulated    = 1; // Emulated by embedding a 64-bit predicate in the cmdbuf and copying from the 32-bit source.
     pUniversal->flags.memory64bPredicationSupport     = 1;
     pUniversal->flags.conditionalExecutionSupport     = 1;
     pUniversal->flags.loopExecutionSupport            = 1;

--- a/src/core/hw/gfxip/gfx6/gfx6UniversalCmdBuffer.cpp
+++ b/src/core/hw/gfxip/gfx6/gfx6UniversalCmdBuffer.cpp
@@ -5046,10 +5046,6 @@ void UniversalCmdBuffer::CmdSetPredication(
     bool                accumulateData)
 {
     PAL_ASSERT((pQueryPool == nullptr) || (pGpuMemory == nullptr));
-    PAL_ASSERT(
-        (predType != PredicateType::Boolean32) ||
-        (m_device.Parent()->EngineProperties().perEngine[EngineTypeUniversal].flags.memory32bPredicationSupport != 0)
-    );
 
     m_gfxCmdBufState.flags.clientPredicate = ((pQueryPool != nullptr) || (pGpuMemory != nullptr)) ? 1 : 0;
     m_gfxCmdBufState.flags.packetPredicate = m_gfxCmdBufState.flags.clientPredicate;
@@ -5073,6 +5069,34 @@ void UniversalCmdBuffer::CmdSetPredication(
     }
 
     uint32* pDeCmdSpace = m_deCmdStream.ReserveCommands();
+
+    // If the predicate is 32-bits and the engine does not support that width natively, allocate a 64-bit
+    // embedded predicate, zero it, emit a ME copy from the original to the lower 32-bits of the embedded
+    // predicate, and update `gpuVirtAddr` and `predType`.
+    if ((predType == PredicateType::Boolean32) &&
+        (m_device.Parent()->EngineProperties().perEngine[EngineTypeUniversal].flags.memory32bPredicationSupport == 0))
+    {
+        PAL_ASSERT(gpuVirtAddr != 0);
+        constexpr size_t PredicateDwordSize  = sizeof(uint64) / sizeof(uint32);
+        constexpr size_t PredicateDwordAlign = 16 / sizeof(uint32);
+        gpusize predicateVirtAddr            = 0;
+        uint32* pPredicate                   = CmdAllocateEmbeddedData(PredicateDwordSize,
+                                                                       PredicateDwordAlign,
+                                                                       &predicateVirtAddr);
+        pPredicate[0] = 0;
+        pPredicate[1] = 0;
+        pDeCmdSpace += m_cmdUtil.BuildCopyData(COPY_DATA_SEL_DST_ASYNC_MEMORY,
+                                               predicateVirtAddr,
+                                               COPY_DATA_SEL_SRC_MEMORY,
+                                               gpuVirtAddr,
+                                               COPY_DATA_SEL_COUNT_1DW,
+                                               COPY_DATA_ENGINE_ME,
+                                               COPY_DATA_WR_CONFIRM_WAIT,
+                                               pDeCmdSpace);
+        pDeCmdSpace += m_cmdUtil.BuildPfpSyncMe(pDeCmdSpace);
+        gpuVirtAddr = predicateVirtAddr;
+        predType    = PredicateType::Boolean64;
+    }
 
     pDeCmdSpace += m_cmdUtil.BuildSetPredication(gpuVirtAddr,
                                                  predPolarity,


### PR DESCRIPTION
Basically a port of the gfx9 fallback path. Passes the VK_EXT_conditional_rendering CTS tests on polaris12. VK_EXT_conditional_rendering should now finally be exposed on all gpus using amdvlk.