### PR TITLE
Add setting to cache the GPUMemory mappings for pipeline upload

### DIFF
--- a/src/core/g_palSettings.cpp
+++ b/src/core/g_palSettings.cpp
@@ -164,6 +164,7 @@ void SettingsLoader::SetupDefaults()
     m_settings.overlayReportMes = true;
     m_settings.mipGenUseFastPath = false;
     m_settings.useFp16GenMips = false;
+    m_settings.maxMappedPoolsSize = 0;
     m_settings.tmzEnabled = true;
 #if PAL_DEVELOPER_BUILD
     m_settings.dbgHelperBits = 0x0;
@@ -633,6 +634,11 @@ void SettingsLoader::ReadSettings()
                            &m_settings.useFp16GenMips,
                            InternalSettingScope::PrivatePalKey);
 
+    static_cast<Pal::Device*>(m_pDevice)->ReadSetting(pmaxMappedPoolsSizeStr,
+                           Util::ValueType::Uint64,
+                           &m_settings.maxMappedPoolsSize,
+                           InternalSettingScope::PrivatePalKey);
+
     static_cast<Pal::Device*>(m_pDevice)->ReadSetting(pTmzEnabledStr,
                            Util::ValueType::Boolean,
                            &m_settings.tmzEnabled,
@@ -681,6 +687,11 @@ void SettingsLoader::RereadSettings()
     static_cast<Pal::Device*>(m_pDevice)->ReadSetting(pUseFp16GenMipsStr,
                            Util::ValueType::Boolean,
                            &m_settings.useFp16GenMips,
+                           InternalSettingScope::PrivatePalKey);
+
+    static_cast<Pal::Device*>(m_pDevice)->ReadSetting(pmaxMappedPoolsSizeStr,
+                           Util::ValueType::Uint64,
+                           &m_settings.maxMappedPoolsSize,
                            InternalSettingScope::PrivatePalKey);
 
     static_cast<Pal::Device*>(m_pDevice)->ReadSetting(pUseDccStr,
@@ -1147,6 +1158,11 @@ void SettingsLoader::InitSettingsInfo()
     info.pValuePtr = &m_settings.useFp16GenMips;
     info.valueSize = sizeof(m_settings.useFp16GenMips);
     m_settingsInfoMap.Insert(192229910, info);
+
+    info.type      = SettingType::Uint64;
+    info.pValuePtr = &m_settings.maxMappedPoolsSize;
+    info.valueSize = sizeof(m_settings.maxMappedPoolsSize);
+    m_settingsInfoMap.Insert(3814409436, info);
 
     info.type      = SettingType::Boolean;
     info.pValuePtr = &m_settings.tmzEnabled;

--- a/src/core/g_palSettings.h
+++ b/src/core/g_palSettings.h
@@ -290,6 +290,7 @@ struct PalSettings : public Pal::DriverSettings
     bool                                        overlayReportMes;
     bool                                        mipGenUseFastPath;
     bool                                        useFp16GenMips;
+    gpusize                                     maxMappedPoolsSize;
     bool                                        tmzEnabled;
 #if PAL_DEVELOPER_BUILD
     uint64                                      dbgHelperBits;
@@ -392,6 +393,7 @@ static const char* pDebugForceResourceAdditionalPaddingStr = "#3601080919";
 static const char* pOverlayReportMesStr = "#1685803860";
 static const char* pMipGenUseFastPathStr = "#3353227045";
 static const char* pUseFp16GenMipsStr = "#192229910";
+static const char* pmaxMappedPoolsSizeStr = "#3814409436";
 static const char* pTmzEnabledStr = "#2606194033";
 #if PAL_DEVELOPER_BUILD
 static const char* pDbgHelperBitsStr = "#3894710420";

--- a/src/core/hw/gfxip/pipeline.cpp
+++ b/src/core/hw/gfxip/pipeline.cpp
@@ -912,7 +912,7 @@ Result PipelineUploader::UploadUsingCpu(
     const SectionAddressCalculator& addressCalc,
     void**                          ppMappedPtr)
 {
-    Result result = m_pGpuMemory->Map(&m_pMappedPtr);
+    Result result = m_pDevice->MemMgr()->Map(m_pGpuMemory, &m_pMappedPtr);
     if (result == Result::Success)
     {
         m_pMappedPtr = VoidPtrInc(m_pMappedPtr, static_cast<size_t>(m_baseOffset));
@@ -1141,7 +1141,7 @@ Result PipelineUploader::End(
         else
         {
             PAL_ASSERT(m_pMappedPtr != nullptr);
-            result = m_pGpuMemory->Unmap();
+            m_pDevice->MemMgr()->Unmap(m_pGpuMemory);
         }
 
         m_pMappedPtr = nullptr;

--- a/src/core/settings_core.json
+++ b/src/core/settings_core.json
@@ -1946,6 +1946,23 @@
       "Description": "If mipGenUseFastPath == true and this is true - use the fp16 single-pass GenMips compute pass."
     },
     {
+      "Name": "maxMappedPoolsSize",
+      "Tags": [
+        "Resource Settings",
+        "Performance"
+      ],
+      "Defaults": {
+        "Default": 0
+      },
+      "Flags": {
+        "RereadSetting": true
+      },
+      "Scope": "PrivatePalKey",
+      "Type": "gpusize",
+      "VariableName": "maxMappedPoolsSize",
+      "Description": "If maxMappedPoolsSize > 0 the mapped gpu memory for pipeline creation will not be unmapped. If the total size of mapped pools grows greater than maxMappedPoolsSize, then the least recently used pools will be unmapped."
+    },
+    {
       "Name": "TmzEnabled",
       "Tags": [
         "General"


### PR DESCRIPTION
During pipeline upload the GpuMemory is allocated from the pool. This
memory is mapped, pipeline is uploaded and then the memory is unmapped.
In applications with lots of pipelines being created during rendering,
this causes lots of map/unmap calls and slows down the pipeline upload.

Add a setting that allows the cache of the GpuMemory mapping, so that it
can be reused by another pipeline upload.