### PR TITLE
Add branch prediction guides to PAL assertions

### DIFF
--- a/inc/util/palUtil.h
+++ b/inc/util/palUtil.h
@@ -80,6 +80,14 @@
 constexpr int32_t InvalidFd = -1;
 #endif
 
+#ifdef __has_builtin
+/// A macro that checks for the presence of builtin functions. Will default to false if the compiler does not have
+/// support for doing this check.
+#define PAL_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+#define PAL_HAS_BUILTIN(builtin) 0
+#endif
+
 #if defined(__has_cpp_attribute)
 #define PAL_HAS_CPP_ATTR(attr) __has_cpp_attribute(attr)
 #else

--- a/src/core/os/amdgpu/amdgpuDevice.cpp
+++ b/src/core/os/amdgpu/amdgpuDevice.cpp
@@ -4855,7 +4855,7 @@ Result Device::ParseClkInfo(
             }
             else if ((ioRet < 0) && (errno != EINTR))
             {
-                PAL_ALERT("read pp_dpm_clk info error");
+                PAL_ALERT_ALWAYS_MSG("read pp_dpm_clk info error");
                 result = Result::ErrorUnavailable;
                 break;
             }


### PR DESCRIPTION
We observed ~2% performance improvement (depending on the workload), in builds with assertions enabled.