### PR TITLE
Fix stack buffer overflow in addrlib2

### DIFF
--- a/src/core/addrMgr/addrMgr2/addrMgr2.cpp
+++ b/src/core/addrMgr/addrMgr2/addrMgr2.cpp
@@ -36,9 +36,6 @@ namespace Pal
 namespace AddrMgr2
 {
 
-// Maximum number of mipmap levels we expect to see in an Image.
-constexpr uint32 MaxImageMipLevels = 15;
-
 // =====================================================================================================================
 AddrMgr2::AddrMgr2(
     const Device* pDevice)

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -400,7 +400,7 @@ Result Image::ValidateCreateInfo(
         // Verify the size of the mip-chain is valid for the given image type and format.
         if (ret == Result::Success)
         {
-            if (imageInfo.mipLevels == 0)
+            if ((imageInfo.mipLevels == 0) || (imageInfo.mipLevels > MaxImageMipLevels))
             {
                 ret = Result::ErrorInvalidMipCount;
             }

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -41,6 +41,9 @@ struct     PrivateScreenCreateInfo;
 struct     SubresId;
 enum class ImageAspect : uint32;
 
+// Maximum number of mipmap levels we expect to see in an Image.
+constexpr uint32 MaxImageMipLevels = 15;
+
 // Shift the 64-bit wide address by 8 to get 256 byte-aligned address, and return the low DWORD of that shifted
 // address.
 //

--- a/src/core/imported/addrlib/src/core/addrlib2.cpp
+++ b/src/core/imported/addrlib/src/core/addrlib2.cpp
@@ -1174,6 +1174,7 @@ ADDR_E_RETURNCODE Lib::ComputeSurfaceAddrFromCoordLinear(
         ADDR2_COMPUTE_SURFACE_INFO_INPUT  localIn  = {0};
         ADDR2_COMPUTE_SURFACE_INFO_OUTPUT localOut = {0};
         ADDR2_MIP_INFO                    mipInfo[MaxMipLevels];
+        ADDR_ASSERT(pIn->numMipLevels <= MaxMipLevels);
 
         localIn.bpp          = pIn->bpp;
         localIn.flags        = pIn->flags;

--- a/src/core/imported/addrlib/src/gfx10/gfx10addrlib.cpp
+++ b/src/core/imported/addrlib/src/gfx10/gfx10addrlib.cpp
@@ -31,6 +31,7 @@
 */
 
 #include "gfx10addrlib.h"
+#include "addrcommon.h"
 #include "gfx10_gb_reg.h"
 
 #include "amdgpu_asic_addr.h"
@@ -2241,6 +2242,7 @@ ADDR_E_RETURNCODE Gfx10Lib::HwlComputeNonBlockCompressedView(
         infoIn.numFrags     = 1;
 
         ADDR2_MIP_INFO mipInfo[MaxMipLevels] = {};
+        ADDR_ASSERT(pIn->numMipLevels <= MaxMipLevels);
 
         ADDR2_COMPUTE_SURFACE_INFO_OUTPUT infoOut = {};
         infoOut.pMipInfo = mipInfo;
@@ -3577,6 +3579,7 @@ ADDR_E_RETURNCODE Gfx10Lib::ComputeSurfaceInfoMacroTiled(
                 UINT_64       mipSize[MaxMipLevels];
                 UINT_64       mipSliceSize[MaxMipLevels];
 
+                ADDR_ASSERT(pIn->numMipLevels <= MaxMipLevels);
                 Dim3d fixedTailMaxDim = tailMaxDim;
 
                 if (m_settings.dsMipmapHtileFix && IsZOrderSwizzle(pIn->swizzleMode) && (index <= 1))
@@ -4249,6 +4252,7 @@ ADDR_E_RETURNCODE Gfx10Lib::ComputeSurfaceAddrFromCoordMicroTiled(
     ADDR2_COMPUTE_SURFACE_INFO_INPUT  localIn  = {};
     ADDR2_COMPUTE_SURFACE_INFO_OUTPUT localOut = {};
     ADDR2_MIP_INFO                    mipInfo[MaxMipLevels];
+    ADDR_ASSERT(pIn->numMipLevels <= MaxMipLevels);
 
     localIn.swizzleMode  = pIn->swizzleMode;
     localIn.flags        = pIn->flags;
@@ -4315,6 +4319,7 @@ ADDR_E_RETURNCODE Gfx10Lib::ComputeSurfaceAddrFromCoordMacroTiled(
     ADDR2_COMPUTE_SURFACE_INFO_INPUT  localIn  = {};
     ADDR2_COMPUTE_SURFACE_INFO_OUTPUT localOut = {};
     ADDR2_MIP_INFO                    mipInfo[MaxMipLevels];
+    ADDR_ASSERT(pIn->numMipLevels <= MaxMipLevels);
 
     localIn.swizzleMode  = pIn->swizzleMode;
     localIn.flags        = pIn->flags;


### PR DESCRIPTION
Make sure we do not write past the end of fix-sized arrays.
Validate the number of mip levels during image creation.