### PR TITLE
environment variable APPDATA is not available in linux on default, in…

### DIFF
--- a/src/core/os/nullDevice/ndDevice.cpp
+++ b/src/core/os/nullDevice/ndDevice.cpp
@@ -1654,8 +1654,12 @@ void Device::InitOutputPaths()
     // Initialize the root path of cache files and debug files
     // Cascade:
     // 1. Find APPDATA to keep backward compatibility.
-    pPath = getenv("APPDATA");
-
+    #ifdef WIN_OS
+        pPath = getenv("APPDATA");
+    #else
+        pPath = "/tmp";
+    #endif
+    
     if (pPath != nullptr)
     {
         Strncpy(m_cacheFilePath, pPath, sizeof(m_cacheFilePath));


### PR DESCRIPTION
…stead use /tmp folder

On most of linux distros, pPath = getenv("APPDATA") is returning null. When executing "Strncpy(m_cacheFilePath, pPath, sizeof(m_cacheFilePath));" in "Device::InitOutputPaths()", pPath is staying null. Because of that, m_cacheFilePath is receiving null value.  That causes an issue as below.

In llpcCompiler.cpp:459,
const char *shaderCachePath = cl::ShaderCacheFileDir.c_str();

shaderCachePath is assigned as null which causes empty() to return true. On linux, it enters into llvm_unreachable...

f (cl::ShaderCacheFileDir.empty()) {
#ifdef WIN_OS
    shaderCachePath = getenv("LOCALAPPDATA");
    assert(shaderCachePath);
#else
    llvm_unreachable("Should never be called!");
#endif
  }