### PR TITLE
Fix incorrect reference in Queue

### DIFF
--- a/shared/devdriver/shared/legacy/inc/util/queue.h
+++ b/shared/devdriver/shared/legacy/inc/util/queue.h
@@ -368,7 +368,7 @@ namespace DevDriver
 
         // Private copy constructor to prevent implicit copies
         Queue(const Queue& rhs)
-            : Queue(rhs.allocCb)
+            : Queue(rhs.m_allocCb)
         {
             GrowBlocks(rhs.m_numBlocks);
             for (int i = 0; i < rhs.m_size; i++)


### PR DESCRIPTION
Fixes an issue I had when building amdvlk with clang 19:
```
/var/tmp/portage/media-libs/amdvlk-2024.3.3/work/pal/shared/devdriver/shared/legacy/inc/util/queue.h:371:25: error: no member named 'allocCb' in 'Queue<T, BlockSize, MinIndexCacheSize>'; did you mean 'm_allocCb'?
  371 |             : Queue(rhs.allocCb)
      |                         ^~~~~~~
      |                         m_allocCb
/var/tmp/portage/media-libs/amdvlk-2024.3.3/work/pal/shared/devdriver/shared/legacy/inc/util/queue.h:367:17: note: 'm_allocCb' declared here
  367 |         AllocCb m_allocCb;
```