### PR TITLE
Add missing cstdio header for sscanf calls

### DIFF
--- a/src/core/misc/cacheLayer/multiElfCacheLayer.cpp
+++ b/src/core/misc/cacheLayer/multiElfCacheLayer.cpp
@@ -24,6 +24,7 @@
  **********************************************************************************************************************/
 #include "multiElfCacheLayer.h"
 #include <cinttypes>
+#include <cstdio>
 
 namespace Util
 {


### PR DESCRIPTION
Fixes new building errors on (at least) clang