### PR TITLE
Fix detection of present on separate GPU for the Wayland dmabuf case

### DIFF
--- a/src/core/os/amdgpu/wayland/waylandWindowSystem.cpp
+++ b/src/core/os/amdgpu/wayland/waylandWindowSystem.cpp
@@ -1301,11 +1301,8 @@ void WaylandWindowSystem::ConfigPresentOnSameGpu()
             drmNodeMinor = drmProps.primaryDrmNodeMinor;
 
         }
-        if ((major(m_DmaDevice) == drmNodeMajor) &&
-            (minor(m_DmaDevice) == drmNodeMinor))
-        {
-            m_presentOnSameGpu = true;
-        }
+        m_presentOnSameGpu = ((major(m_DmaDevice) == drmNodeMajor) &&
+            (minor(m_DmaDevice) == drmNodeMinor));
     }
     else
     {


### PR DESCRIPTION
WaylandWindowSystem::m_presentOnSameGpu is set to true on initialisation and was never being set to false in the case where the presenting drm device was different from the render device.

Fixes GPUOpen-Drivers/AMDVLK#393