### PR TITLE
Add ability for the viewport to override the depth clamp range

### DIFF
--- a/inc/core/palCmdBuffer.h
+++ b/inc/core/palCmdBuffer.h
@@ -1859,6 +1859,13 @@ struct Viewport
     PointOrigin origin;    ///< Origin of the viewport relative to NDC. UpperLeft or LowerLeft.
 };
 
+/// Specifies range for user-defined depth clamp
+struct DepthClamp
+{
+    float minDepth; ///< Minimum depth value after viewport transform.
+    float maxDepth; ///< Maximum depth value after viewport transform.
+};
+
 /// Specifies the viewport transform parameters for setting a single viewport.
 /// @see ICmdBuffer::CmdSetViewport
 struct ViewportParams
@@ -1872,6 +1879,8 @@ struct ViewportParams
     float      horzClipRatio;           ///< The ratio between guardband clip rect width and viewport width.
     float      vertClipRatio;           ///< The ratio between guardband clip rect height and viewport height.
     DepthRange depthRange;              ///< Specifies the target range of Z values
+    DepthClamp depthClampOverride;      ///< Specifies the clamp range of Z values for DepthClampMode::Viewport.
+                                        ///  minDepth > maxDepth means that the override is not active.
     // Define viewports array at the end of the structure as it is common to only access the first N from the CPU.
     Viewport   viewports[MaxViewports]; ///< Array of desciptors for each viewport.
 };

--- a/src/core/hw/gfxip/gfx12/gfx12UniversalCmdBuffer.cpp
+++ b/src/core/hw/gfxip/gfx12/gfx12UniversalCmdBuffer.cpp
@@ -1357,6 +1357,13 @@ void UniversalCmdBuffer::WriteViewports(
         }
         else
 #endif
+        if (static_cast<DepthClampMode>(m_graphicsState.depthClampMode) == DepthClampMode::Viewport &&
+            vpParams.depthClampOverride.minDepth <= vpParams.depthClampOverride.maxDepth)
+        {
+            viewportRegs.vp[i].zMin.f32All = vpParams.depthClampOverride.minDepth;
+            viewportRegs.vp[i].zMax.f32All = vpParams.depthClampOverride.maxDepth;
+        }
+        else
         {
             viewportRegs.vp[i].zMin.f32All = Min(viewport.minDepth, viewport.maxDepth);
             viewportRegs.vp[i].zMax.f32All = Max(viewport.minDepth, viewport.maxDepth);

--- a/src/core/hw/gfxip/gfx9/gfx9UniversalCmdBuffer.cpp
+++ b/src/core/hw/gfxip/gfx9/gfx9UniversalCmdBuffer.cpp
@@ -7711,6 +7711,13 @@ uint32* UniversalCmdBuffer::ValidateViewports(
         }
         else
 #endif
+        if (static_cast<DepthClampMode>(m_graphicsState.depthClampMode) == DepthClampMode::Viewport &&
+            params.depthClampOverride.minDepth <= params.depthClampOverride.maxDepth)
+        {
+            pZMinMaxImg->zMin.f32All = params.depthClampOverride.minDepth;
+            pZMinMaxImg->zMax.f32All = params.depthClampOverride.maxDepth;
+        }
+        else
         {
             pZMinMaxImg->zMin.f32All = Min(viewport.minDepth, viewport.maxDepth);
             pZMinMaxImg->zMax.f32All = Max(viewport.minDepth, viewport.maxDepth);

--- a/src/core/hw/gfxip/rpm/gfx12/gfx12RsrcProcMgr.cpp
+++ b/src/core/hw/gfxip/rpm/gfx12/gfx12RsrcProcMgr.cpp
@@ -1319,6 +1319,7 @@ void RsrcProcMgr::DepthStencilClearGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo    = {};
     scissorInfo.count                = 1;

--- a/src/core/hw/gfxip/rpm/gfx9/gfx9RsrcProcMgr.cpp
+++ b/src/core/hw/gfxip/rpm/gfx9/gfx9RsrcProcMgr.cpp
@@ -1185,6 +1185,7 @@ bool RsrcProcMgr::ExpandDepthStencil(
         viewportInfo.vertClipRatio         = FLT_MAX;
         viewportInfo.vertDiscardRatio      = 1.0f;
         viewportInfo.depthRange            = DepthRange::ZeroToOne;
+        viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
         ScissorRectParams scissorInfo      = { };
         scissorInfo.count                  = 1;
@@ -2020,6 +2021,7 @@ void RsrcProcMgr::ResolveImageDepthStencilCopy(
     viewportInfo.vertClipRatio    = FLT_MAX;
     viewportInfo.vertDiscardRatio = 1.0f;
     viewportInfo.depthRange       = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = {};
     scissorInfo.count = 1;
@@ -2248,6 +2250,7 @@ void RsrcProcMgr::HwlResolveImageGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;
@@ -2771,6 +2774,7 @@ void RsrcProcMgr::DepthStencilClearGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo      = { };
     scissorInfo.count                  = 1;

--- a/src/core/hw/gfxip/rpm/rsrcProcMgr.cpp
+++ b/src/core/hw/gfxip/rpm/rsrcProcMgr.cpp
@@ -3368,6 +3368,7 @@ void RsrcProcMgr::CmdClearBoundDepthStencilTargets(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;
@@ -3450,6 +3451,7 @@ void RsrcProcMgr::CmdClearBoundColorTargets(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;
@@ -5595,6 +5597,7 @@ void RsrcProcMgr::ResummarizeDepthStencil(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo    = { };
     scissorInfo.count                = 1;
@@ -5876,6 +5879,7 @@ void RsrcProcMgr::SlowClearGraphics(
         viewportInfo.vertClipRatio         = FLT_MAX;
         viewportInfo.vertDiscardRatio      = 1.0f;
         viewportInfo.depthRange            = DepthRange::ZeroToOne;
+        viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
         const bool  is3dImage  = (createInfo.imageType == ImageType::Tex3d);
         ColorTargetViewCreateInfo colorViewInfo       = { };
@@ -6016,6 +6020,7 @@ void RsrcProcMgr::GenericColorBlit(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ColorTargetViewInternalCreateInfo colorViewInfoInternal = { };
     colorViewInfoInternal.flags.dccDecompress   = (pipeline == RpmGfxPipeline::DccDecompress);
@@ -6381,6 +6386,7 @@ void RsrcProcMgr::ResolveImageDepthStencilGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;
@@ -6593,6 +6599,7 @@ void RsrcProcMgr::ResolveImageFixedFunc(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;
@@ -6868,6 +6875,7 @@ void RsrcProcMgr::ScaledCopyImageGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = {};
     scissorInfo.count             = 1;
@@ -7660,6 +7668,7 @@ void RsrcProcMgr::CopyDepthStencilImageGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;
@@ -7988,6 +7997,7 @@ void RsrcProcMgr::CopyColorImageGraphics(
     viewportInfo.vertClipRatio         = FLT_MAX;
     viewportInfo.vertDiscardRatio      = 1.0f;
     viewportInfo.depthRange            = DepthRange::ZeroToOne;
+    viewportInfo.depthClampOverride    = { 1.0f, 0.0f };
 
     ScissorRectParams scissorInfo = { };
     scissorInfo.count = 1;

--- a/src/core/hw/gfxip/universalCmdBuffer.cpp
+++ b/src/core/hw/gfxip/universalCmdBuffer.cpp
@@ -244,6 +244,8 @@ void UniversalCmdBuffer::ResetState()
     m_graphicsState.viewportState.vertClipRatio    = 1.0f;
     m_graphicsState.viewportState.vertDiscardRatio = 1.0f;
 
+    // No depth clamp override by default
+    m_graphicsState.viewportState.depthClampOverride = { 1.0f, 0.0f };
 }
 
 // =====================================================================================================================
@@ -746,6 +748,8 @@ void UniversalCmdBuffer::SetGraphicsState(
         (restoreViewports.vertDiscardRatio != currentViewports.vertDiscardRatio) ||
         (restoreViewports.horzClipRatio    != currentViewports.horzClipRatio)    ||
         (restoreViewports.vertClipRatio    != currentViewports.vertClipRatio)    ||
+        (restoreViewports.depthClampOverride.minDepth != currentViewports.depthClampOverride.minDepth) ||
+        (restoreViewports.depthClampOverride.maxDepth != currentViewports.depthClampOverride.maxDepth) ||
         (memcmp(&restoreViewports.viewports[0],
                 &currentViewports.viewports[0],
                 restoreViewports.count * sizeof(restoreViewports.viewports[0])) != 0))

--- a/src/core/layers/cmdBufferLogger/cmdBufferLoggerCmdBuffer.cpp
+++ b/src/core/layers/cmdBufferLogger/cmdBufferLoggerCmdBuffer.cpp
@@ -2142,6 +2142,12 @@ static void ViewportParamsToString(
     Snprintf(pString, StringLength, " depthRange       = %s",
              (params.depthRange == DepthRange::ZeroToOne) ? "ZeroToOne" : "NegativeOneToOne");
     pCmdBuffer->GetNextLayer()->CmdCommentString(pString);
+    pCmdBuffer->GetNextLayer()->CmdCommentString(" depthClampOverride = {");
+    Snprintf(pString, StringLength, " \tminDepth = %f", viewport.depthClampOverride.minDepth);
+    pCmdBuffer->GetNextLayer()->CmdCommentString(pString);
+    Snprintf(pString, StringLength, " \tmaxDepth = %f", viewport.depthClampOverride.maxDepth);
+    pCmdBuffer->GetNextLayer()->CmdCommentString(pString);
+    pCmdBuffer->GetNextLayer()->CmdCommentString(" } // depthClampOverride");
 
     pCmdBuffer->GetNextLayer()->CmdCommentString("] // params");
 

--- a/src/core/layers/interfaceLogger/interfaceLoggerLogContextStruct.cpp
+++ b/src/core/layers/interfaceLogger/interfaceLoggerLogContextStruct.cpp
@@ -4147,6 +4147,16 @@ void LogContext::Struct(
 
 // =====================================================================================================================
 void LogContext::Struct(
+    const DepthClamp& value)
+{
+    BeginMap(false);
+    KeyAndValue("minDepth", value.minDepth);
+    KeyAndValue("maxDepth", value.maxDepth);
+    EndMap();
+}
+
+// =====================================================================================================================
+void LogContext::Struct(
     const ViewportParams& value)
 {
     BeginMap(false);
@@ -4170,6 +4180,7 @@ void LogContext::Struct(
     KeyAndValue("vertDiscardRatio", value.vertDiscardRatio);
     KeyAndValue("horzClipRatio", value.horzClipRatio);
     KeyAndValue("vertClipRatio", value.vertClipRatio);
+    KeyAndValue("depthClampOverride", value.depthClampOverride);
     EndMap();
 }
 


### PR DESCRIPTION
This is required for the correct implementation of `VK_EXT_depth_clamp_control`.

See the corresponding XGL PR for further context: https://github.com/GPUOpen-Drivers/xgl/pull/183